### PR TITLE
Xzhu

### DIFF
--- a/src/com/scu/coen383/team2/scheduling/Main.java
+++ b/src/com/scu/coen383/team2/scheduling/Main.java
@@ -3,17 +3,17 @@ package com.scu.coen383.team2.scheduling;
 import java.util.PriorityQueue;
 
 public class Main {
-    private static final int COUNT_ALGORITHM = 8;
+    private static final int COUNT_ALGORITHM = 9;
 
     public static void main(String[] args) {
 
 
         // loading Scheduling algorithms here
-        FirstComeFirstServed FCFS = new FirstComeFirstServed();
-        NonpreemptiveHighestPriorityFirst NP_HPF = new NonpreemptiveHighestPriorityFirst();
-        PreemptiveHighestPriorityFirst P_HPF = new PreemptiveHighestPriorityFirst();
-
-        NonpreemptiveHighestPriorityFirstAging NP_HPF_AG = new NonpreemptiveHighestPriorityFirstAging();
+        FirstComeFirstServed                    FCFS        = new FirstComeFirstServed();
+        NonpreemptiveHighestPriorityFirst       NP_HPF      = new NonpreemptiveHighestPriorityFirst();
+        PreemptiveHighestPriorityFirst          P_HPF       = new PreemptiveHighestPriorityFirst();
+        NonpreemptiveHighestPriorityFirstAging  NP_HPF_AG   = new NonpreemptiveHighestPriorityFirstAging();
+        PreemptiveHighestPriorityFirstAging     P_HPF_AG    = new PreemptiveHighestPriorityFirstAging();
 
         PriorityQueue<Process>[] priorityQueues =  new PriorityQueue[COUNT_ALGORITHM + 1];
 
@@ -36,13 +36,15 @@ public class Main {
         FCFS.schedule(priorityQueues[0]);
 
 
-        System.out.println("\nNonpreemptive Highest Priority First (No Aging)");
+        System.out.println("\nNonpreemptive Highest Priority First");
         NP_HPF.schedule(priorityQueues[5]);
         System.out.println("\nNonpreemptive Highest Priority First (Aging)");
-        NP_HPF_AG.schedule(priorityQueues[7]);
+        NP_HPF_AG.schedule(priorityQueues[6]);
 
-        System.out.println("\nPreemptive Highest Priority First (No Aging)");
-        P_HPF.schedule(priorityQueues[6]);
+        System.out.println("\nPreemptive Highest Priority First");
+        P_HPF.schedule(priorityQueues[7]);
+        System.out.println("\nPreemptive Highest Priority First (Aging)");
+        P_HPF_AG.schedule(priorityQueues[8]);
 
 
 

--- a/src/com/scu/coen383/team2/scheduling/Main.java
+++ b/src/com/scu/coen383/team2/scheduling/Main.java
@@ -13,6 +13,7 @@ public class Main {
         NonpreemptiveHighestPriorityFirst NP_HPF = new NonpreemptiveHighestPriorityFirst();
         PreemptiveHighestPriorityFirst P_HPF = new PreemptiveHighestPriorityFirst();
 
+        NonpreemptiveHighestPriorityFirstAging NP_HPF_AG = new NonpreemptiveHighestPriorityFirstAging();
 
         PriorityQueue<Process>[] priorityQueues =  new PriorityQueue[COUNT_ALGORITHM + 1];
 
@@ -37,9 +38,13 @@ public class Main {
 
         System.out.println("\nNonpreemptive Highest Priority First (No Aging)");
         NP_HPF.schedule(priorityQueues[5]);
+        System.out.println("\nNonpreemptive Highest Priority First (Aging)");
+        NP_HPF_AG.schedule(priorityQueues[7]);
 
         System.out.println("\nPreemptive Highest Priority First (No Aging)");
         P_HPF.schedule(priorityQueues[6]);
+
+
 
     }
 }

--- a/src/com/scu/coen383/team2/scheduling/NonpreemptiveHighestPriorityFirst.java
+++ b/src/com/scu/coen383/team2/scheduling/NonpreemptiveHighestPriorityFirst.java
@@ -20,11 +20,9 @@ public class NonpreemptiveHighestPriorityFirst extends ScheduleBase {
 
         // in priority ascending order
         // in arrivalTime ascending order for same priority
-        PriorityQueue<Process> readyQueue = new PriorityQueue<>((o1, o2) -> {
-            return o1.getPriority() == o2.getPriority()
-                    ? Float.compare(o1.getArrivalTime(), o2.getArrivalTime())
-                    : Integer.compare(o1.getPriority(), o2.getPriority());
-        });
+        PriorityQueue<Process> readyQueue = new PriorityQueue<>((o1, o2) -> o1.getPriority() == o2.getPriority()
+                ? Float.compare(o1.getArrivalTime(), o2.getArrivalTime())
+                : Integer.compare(o1.getPriority(), o2.getPriority()));
 
         while (!initialQueue.isEmpty() || ! readyQueue.isEmpty()) {
             // fectch ready process from initalQueue, put them into ready Queue, waiting for execution

--- a/src/com/scu/coen383/team2/scheduling/NonpreemptiveHighestPriorityFirstAging.java
+++ b/src/com/scu/coen383/team2/scheduling/NonpreemptiveHighestPriorityFirstAging.java
@@ -12,7 +12,7 @@ import java.util.Queue;
     Process with same priority are scheduled by FCFS
  */
 
-public class NonpreemptiveHighestPriorityFirstAging extends ScheduleBase {
+public class NonpreemptiveHighestPriorityFirstAging extends SchedulePriority {
     public Queue<Process> schedule(PriorityQueue<Process> initialQueue) {
         Queue<Process> scheduledQueue = new LinkedList<>();
 
@@ -22,21 +22,21 @@ public class NonpreemptiveHighestPriorityFirstAging extends ScheduleBase {
         Process scheduled;
         ScheduleBase.Stats stats = getStats();
 
-    /*
-        readyQueues:
-        [
-            [...]
-            [p0, p1, p2, ... pi]
-            [...]
-            [...]
-         ]
-         Each time, we pick up the first nonempty row as current Queue,
-         which is the row with highest priority.
-         When we do nonpreemptive HPF with Aging, we update each process in
-         this readyQueues, increase their age by one, if some of them wait
-         long enough, let's say it has waited for 5 quanta, we promote it
-         to a higher priority level, put it to the end of [i-1] row.
-     */
+        /*
+            readyQueues:
+            [
+                [...]
+                [p0, p1, p2, ... pi]
+                [...]
+                [...]
+             ]
+             Each time, we pick up the first nonempty row as current Queue,
+             which is the row with highest priority.
+             When we do nonpreemptive HPF with Aging, we update each process in
+             this readyQueues, increase their age by one, if some of them wait
+             long enough, let's say it has waited for 5 quanta, we promote it
+             to a higher priority level, put it to the end of [i-1] row.
+        */
         Queue<Process>[] readyQueues = new Queue[MAX_PRIORITY];
         for (int i = 0; i < MAX_PRIORITY ; i++) {
             readyQueues[i] = new LinkedList<>();
@@ -80,44 +80,4 @@ public class NonpreemptiveHighestPriorityFirstAging extends ScheduleBase {
 
         return scheduledQueue;
     }
-
-    private void updatePriority(Queue<Process>[] readyQueues) {
-        for (int i = 0; i < MAX_PRIORITY; i++) {
-            for (Process p: readyQueues[i]) {
-                if (p.addAge() && i > 0) {
-                    // here we are, get p out from current level
-                    // then add it to higher level
-                    readyQueues[i].remove(p);
-                    readyQueues[i-1].add(p);
-                }
-            }
-        }
-    }
-
-
-    private Process setScheduled(int startTime, float serviceTime, Process process) {
-        return new Process(
-                process.getName(),
-                process.getArrivalTime(),
-                serviceTime,
-                process.getPriority(),
-                startTime);
-    }
-
-    private void statsState(int startTime, int finishTime, Process process, Stats stats) {
-
-        stats.addTurnaroundTime(finishTime - process.getArrivalTime());                     // finishTime - arrivalTime
-        stats.addResponseTime(startTime - process.getArrivalTime());                        // startTime - arrivalTime
-        stats.addWaitTime(finishTime - process.getArrivalTime() - process.getServiceTime());// turnaroundTime - serviceTime
-        stats.addProcess();
-    }
-
-    private int highestQueue(Queue<Process>[] queues) {
-
-        for (int i = 0; i < MAX_PRIORITY; i++) {
-            if (!queues[i].isEmpty()) return i;
-        }
-        return MAX_PRIORITY;
-    }
-
 }

--- a/src/com/scu/coen383/team2/scheduling/NonpreemptiveHighestPriorityFirstAging.java
+++ b/src/com/scu/coen383/team2/scheduling/NonpreemptiveHighestPriorityFirstAging.java
@@ -19,7 +19,6 @@ public class NonpreemptiveHighestPriorityFirstAging extends SchedulePriority {
         int finishTime = 0;
         int startTime;
         Process process;
-        Process scheduled;
         ScheduleBase.Stats stats = getStats();
 
         /*

--- a/src/com/scu/coen383/team2/scheduling/NonpreemptiveHighestPriorityFirstAging.java
+++ b/src/com/scu/coen383/team2/scheduling/NonpreemptiveHighestPriorityFirstAging.java
@@ -1,5 +1,6 @@
 package com.scu.coen383.team2.scheduling;
 
+import javax.rmi.ssl.SslRMIClientSocketFactory;
 import java.util.LinkedList;
 import java.util.PriorityQueue;
 import java.util.Queue;
@@ -13,17 +14,97 @@ import java.util.Queue;
  */
 
 public class NonpreemptiveHighestPriorityFirstAging extends ScheduleBase {
-    public Queue<Process> schedule(PriorityQueue<Process> q) {
+    public Queue<Process> schedule(PriorityQueue<Process> initialQueue) {
         Queue<Process> scheduledQueue = new LinkedList<>();
 
         int finishTime = 0;
         int startTime;
         Process process;
         Process scheduled;
-        ScheduleBase.Stats stats;
+        ScheduleBase.Stats stats = getStats();
 
 
+        Queue<Process>[] readyQueues = new Queue[MAX_PRIORITY];
+        for (int i = 0; i < MAX_PRIORITY ; i++) {
+            readyQueues[i] = new LinkedList<>();
+        }
+
+        int curQueueIndex = MAX_PRIORITY;
+        while (curQueueIndex < MAX_PRIORITY || !initialQueue.isEmpty()) {
+
+            // fetch process from initialQueue and put them into corresponding readyQueue
+            while (!initialQueue.isEmpty() && initialQueue.peek().getArrivalQuanta() <= finishTime) {
+                readyQueues[initialQueue.peek().getPriority() - 1].add(initialQueue.poll());
+            }
+
+            curQueueIndex = highestQueue(readyQueues);
+            // both of readyQueue and initialQueue are empty, we are done
+            if (curQueueIndex == MAX_PRIORITY && initialQueue.isEmpty()) break;
+
+            process = curQueueIndex < MAX_PRIORITY ? readyQueues[curQueueIndex].poll() : initialQueue.poll();
+            startTime = Math.max(process.getArrivalQuanta(), finishTime);
+            finishTime = startTime + process.getServiceQuanta();
+
+            if (startTime > 99) break;
+
+            // build the timeline for current process, nonpreemptive
+            for (int i = startTime; i < finishTime; i++) {
+                // update priority of every process in readyQueues
+                // upgrade it if necessary
+                updatePriority(readyQueues);
+
+                scheduled = setScheduled(i, 1, process);
+                scheduledQueue.add(scheduled);
+            }
+
+            statsState(startTime, finishTime, process, stats);
+        }
+
+        stats.addQuanta(finishTime);
+        printTimeChart(scheduledQueue);
+        printRoundAvg();
+        stats.nextRound();
 
         return scheduledQueue;
     }
+
+    private void updatePriority(Queue<Process>[] readyQueues) {
+        for (int i = 0; i < MAX_PRIORITY; i++) {
+            for (Process p: readyQueues[i]) {
+                if (p.addAge() && i > 0) {
+                    // here we are, get p out from current level
+                    // then add it to higher level
+                    readyQueues[i].remove(p);
+                    readyQueues[i-1].add(p);
+                }
+            }
+        }
+    }
+
+
+    private Process setScheduled(int startTime, float serviceTime, Process process) {
+        return new Process(
+                process.getName(),
+                process.getArrivalTime(),
+                serviceTime,
+                process.getPriority(),
+                startTime);
+    }
+
+    private void statsState(int startTime, int finishTime, Process process, Stats stats) {
+
+        stats.addTurnaroundTime(finishTime - process.getArrivalTime());                     // finishTime - arrivalTime
+        stats.addResponseTime(startTime - process.getArrivalTime());                        // startTime - arrivalTime
+        stats.addWaitTime(finishTime - process.getArrivalTime() - process.getServiceTime());// turnaroundTime - serviceTime
+        stats.addProcess();
+    }
+
+    private int highestQueue(Queue<Process>[] queues) {
+
+        for (int i = 0; i < MAX_PRIORITY; i++) {
+            if (!queues[i].isEmpty()) return i;
+        }
+        return MAX_PRIORITY;
+    }
+
 }

--- a/src/com/scu/coen383/team2/scheduling/NonpreemptiveHighestPriorityFirstAging.java
+++ b/src/com/scu/coen383/team2/scheduling/NonpreemptiveHighestPriorityFirstAging.java
@@ -11,9 +11,18 @@ import java.util.Queue;
     After a process has waited for 5 quanta at a priority level, bump it up to next higher level.
     Process with same priority are scheduled by FCFS
  */
+
 public class NonpreemptiveHighestPriorityFirstAging extends ScheduleBase {
     public Queue<Process> schedule(PriorityQueue<Process> q) {
         Queue<Process> scheduledQueue = new LinkedList<>();
+
+        int finishTime = 0;
+        int startTime;
+        Process process;
+        Process scheduled;
+        ScheduleBase.Stats stats;
+
+
 
         return scheduledQueue;
     }

--- a/src/com/scu/coen383/team2/scheduling/NonpreemptiveHighestPriorityFirstAging.java
+++ b/src/com/scu/coen383/team2/scheduling/NonpreemptiveHighestPriorityFirstAging.java
@@ -1,0 +1,20 @@
+package com.scu.coen383.team2.scheduling;
+
+import java.util.LinkedList;
+import java.util.PriorityQueue;
+import java.util.Queue;
+
+/*
+    Ref: https://www.geeksforgeeks.org/program-for-preemptive-priority-cpu-scheduling/
+         https://www.cs.rutgers.edu/~pxk/416/notes/07-scheduling.html
+
+    After a process has waited for 5 quanta at a priority level, bump it up to next higher level.
+    Process with same priority are scheduled by FCFS
+ */
+public class NonpreemptiveHighestPriorityFirstAging extends ScheduleBase {
+    public Queue<Process> schedule(PriorityQueue<Process> q) {
+        Queue<Process> scheduledQueue = new LinkedList<>();
+
+        return scheduledQueue;
+    }
+}

--- a/src/com/scu/coen383/team2/scheduling/NonpreemptiveHighestPriorityFirstAging.java
+++ b/src/com/scu/coen383/team2/scheduling/NonpreemptiveHighestPriorityFirstAging.java
@@ -61,14 +61,7 @@ public class NonpreemptiveHighestPriorityFirstAging extends SchedulePriority {
             if (startTime > 99) break;
 
             // build the timeline for current process, nonpreemptive
-            for (int i = startTime; i < finishTime; i++) {
-                // update priority of every process in readyQueues
-                // upgrade it if necessary
-                updatePriority(readyQueues);
-
-                scheduled = setScheduled(i, 1, process);
-                scheduledQueue.add(scheduled);
-            }
+            updateReadyQueues(startTime, finishTime, process, readyQueues, scheduledQueue);
 
             statsState(startTime, finishTime, process, stats);
         }
@@ -79,5 +72,20 @@ public class NonpreemptiveHighestPriorityFirstAging extends SchedulePriority {
         stats.nextRound();
 
         return scheduledQueue;
+    }
+
+    private void updateReadyQueues(int startTime,
+                                   int finishTime,
+                               Process process,
+                               Queue<Process>[] readyQueues,
+                               Queue<Process> scheduledQueue) {
+        for (int i = startTime; i < finishTime; i++) {
+            // update priority of every process in readyQueues
+            // upgrade it if necessary
+            updatePriority(readyQueues);
+
+            Process scheduled = setScheduled(i, 1, process);
+            scheduledQueue.add(scheduled);
+        }
     }
 }

--- a/src/com/scu/coen383/team2/scheduling/NonpreemptiveHighestPriorityFirstAging.java
+++ b/src/com/scu/coen383/team2/scheduling/NonpreemptiveHighestPriorityFirstAging.java
@@ -1,6 +1,5 @@
 package com.scu.coen383.team2.scheduling;
 
-import javax.rmi.ssl.SslRMIClientSocketFactory;
 import java.util.LinkedList;
 import java.util.PriorityQueue;
 import java.util.Queue;
@@ -23,7 +22,21 @@ public class NonpreemptiveHighestPriorityFirstAging extends ScheduleBase {
         Process scheduled;
         ScheduleBase.Stats stats = getStats();
 
-
+    /*
+        readyQueues:
+        [
+            [...]
+            [p0, p1, p2, ... pi]
+            [...]
+            [...]
+         ]
+         Each time, we pick up the first nonempty row as current Queue,
+         which is the row with highest priority.
+         When we do nonpreemptive HPF with Aging, we update each process in
+         this readyQueues, increase their age by one, if some of them wait
+         long enough, let's say it has waited for 5 quanta, we promote it
+         to a higher priority level, put it to the end of [i-1] row.
+     */
         Queue<Process>[] readyQueues = new Queue[MAX_PRIORITY];
         for (int i = 0; i < MAX_PRIORITY ; i++) {
             readyQueues[i] = new LinkedList<>();

--- a/src/com/scu/coen383/team2/scheduling/PreemptiveHighestPriorityFirst.java
+++ b/src/com/scu/coen383/team2/scheduling/PreemptiveHighestPriorityFirst.java
@@ -8,7 +8,11 @@ import java.util.Queue;
 
 /*
     Ref: https://www.geeksforgeeks.org/program-for-preemptive-priority-cpu-scheduling/
+         https://www.cs.rutgers.edu/~pxk/416/notes/07-scheduling.html
+
+    Use RR with time slice of 1 quantum for each piority queue
  */
+
 public class PreemptiveHighestPriorityFirst extends ScheduleBase {
     private static int MAX_PRIORITY = 4;
 

--- a/src/com/scu/coen383/team2/scheduling/PreemptiveHighestPriorityFirst.java
+++ b/src/com/scu/coen383/team2/scheduling/PreemptiveHighestPriorityFirst.java
@@ -10,7 +10,7 @@ import java.util.Queue;
     Ref: https://www.geeksforgeeks.org/program-for-preemptive-priority-cpu-scheduling/
          https://www.cs.rutgers.edu/~pxk/416/notes/07-scheduling.html
 
-    Use RR with time slice of 1 quantum for each piority queue
+    Use RR with time slice of 1 quantum for each priority queue
  */
 
 public class PreemptiveHighestPriorityFirst extends ScheduleBase {
@@ -27,7 +27,7 @@ public class PreemptiveHighestPriorityFirst extends ScheduleBase {
         HashMap<Character, Float> arrivalTimeTable = new HashMap<>(); // unqiue for every process
         HashMap<Character, Integer> finishTimeTable = new HashMap<>(); // update each round
 
-        Queue<Process>[] readyQueues = new Queue[4];
+        Queue<Process>[] readyQueues = new Queue[MAX_PRIORITY];
         for (int i = 0; i < MAX_PRIORITY ; i++) {
             readyQueues[i] = new LinkedList<>();
         }
@@ -37,8 +37,7 @@ public class PreemptiveHighestPriorityFirst extends ScheduleBase {
 
             // fetch process from initialQueue and put them into corresponding readyQueue
             while (!initialQueue.isEmpty() && initialQueue.peek().getArrivalQuanta() <= finishTime) {
-                int p = initialQueue.peek().getPriority() - 1;
-                readyQueues[p].add(initialQueue.poll());
+                readyQueues[initialQueue.peek().getPriority() - 1].add(initialQueue.poll());
             }
 
             curQueueIndex = highestQueue(readyQueues);

--- a/src/com/scu/coen383/team2/scheduling/PreemptiveHighestPriorityFirst.java
+++ b/src/com/scu/coen383/team2/scheduling/PreemptiveHighestPriorityFirst.java
@@ -14,7 +14,6 @@ import java.util.Queue;
  */
 
 public class PreemptiveHighestPriorityFirst extends ScheduleBase {
-    private static int MAX_PRIORITY = 4;
 
     public Queue<Process> schedule(PriorityQueue<Process> initialQueue) {
         Queue<Process> scheduledQueue = new LinkedList<>();

--- a/src/com/scu/coen383/team2/scheduling/PreemptiveHighestPriorityFirstAging.java
+++ b/src/com/scu/coen383/team2/scheduling/PreemptiveHighestPriorityFirstAging.java
@@ -1,6 +1,5 @@
 package com.scu.coen383.team2.scheduling;
 
-
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.PriorityQueue;
@@ -10,11 +9,11 @@ import java.util.Queue;
     Ref: https://www.geeksforgeeks.org/program-for-preemptive-priority-cpu-scheduling/
          https://www.cs.rutgers.edu/~pxk/416/notes/07-scheduling.html
 
+    After a process has waited for 5 quanta at a priority level, bump it up to next higher level.
     Use RR with time slice of 1 quantum for each priority queue
  */
 
-public class PreemptiveHighestPriorityFirst extends SchedulePriority {
-
+public class PreemptiveHighestPriorityFirstAging extends SchedulePriority{
     public Queue<Process> schedule(PriorityQueue<Process> initialQueue) {
         Queue<Process> scheduledQueue = new LinkedList<>();
 
@@ -64,15 +63,8 @@ public class PreemptiveHighestPriorityFirst extends SchedulePriority {
             startTime = Math.max(process.getArrivalQuanta(), finishTime);
             finishTime = startTime + 1;
 
-
-//            System.out.format("Index: %2d, Name: %c, finishTime: %2d, left: %d, %s\n",
-//                    curQueueIndex,
-////                    readyQueues[curQueueIndex].size(),
-//                    process.getName(),
-//                    finishTime,
-//                    initialQueue.size(),
-//                    process);
-
+            // update priority
+            updatePriority(readyQueues);
 
             // update stats
             updateStats(arrivalTimeTable, finishTimeTable, readyQueues, startTime, finishTime, process, stats);
@@ -88,4 +80,5 @@ public class PreemptiveHighestPriorityFirst extends SchedulePriority {
 
         return scheduledQueue;
     }
+
 }

--- a/src/com/scu/coen383/team2/scheduling/Process.java
+++ b/src/com/scu/coen383/team2/scheduling/Process.java
@@ -20,12 +20,15 @@ public class Process implements Comparable<Process> {
 
     public void     setServiceTime(float newServiceTime)    { _serviceTime = newServiceTime; }
 
-    public void     addAge() {
+    // return true if priority get increased, otherwise return false
+    public boolean  addAge() {
         _age += 1;
         if ( _priority > 1 && 5 == _age) {
             _priority -= 1;
             _age = 0;
+            return true;
         }
+        return false;
     }
 
     Process(char name, float arrival_time, float service_time, int priority, int start_time) {

--- a/src/com/scu/coen383/team2/scheduling/Process.java
+++ b/src/com/scu/coen383/team2/scheduling/Process.java
@@ -7,6 +7,7 @@ public class Process implements Comparable<Process> {
     private float   _arrivalTime;       // arrival time 0 - 99
     private int     _startTime;         // start time
     private float   _serviceTime;       // expected total run time 0.1 - 10
+    private int     _age;
 
     public int      getPriority()       { return _priority; }
     public char     getName()           { return _name; }
@@ -15,8 +16,17 @@ public class Process implements Comparable<Process> {
     public int      getServiceQuanta()  { return (int)Math.ceil(_serviceTime);}
     public int      getArrivalQuanta()  { return (int)Math.ceil((_arrivalTime));}
     public int      getStartTime()      { return _startTime; }
+    public int      getAge()            { return _age;}
 
     public void     setServiceTime(float newServiceTime)    { _serviceTime = newServiceTime; }
+
+    public void     addAge() {
+        _age += 1;
+        if ( _priority > 1 && 5 == _age) {
+            _priority -= 1;
+            _age = 0;
+        }
+    }
 
     Process(char name, float arrival_time, float service_time, int priority, int start_time) {
         _name = name;
@@ -24,6 +34,7 @@ public class Process implements Comparable<Process> {
         _serviceTime = service_time;
         _priority = priority;
         _startTime = start_time;
+        _age  = 0;
     }
 
     Process(Process obj) {
@@ -32,6 +43,7 @@ public class Process implements Comparable<Process> {
         _serviceTime    = obj.getServiceTime();
         _priority       = obj.getPriority();
         _startTime      = obj.getStartTime();
+        _age            = obj.getAge();
     }
 
 

--- a/src/com/scu/coen383/team2/scheduling/ScheduleBase.java
+++ b/src/com/scu/coen383/team2/scheduling/ScheduleBase.java
@@ -4,8 +4,9 @@ import java.util.PriorityQueue;
 import java.util.Queue;
 
 public abstract class ScheduleBase {
-    private Stats stats = new Stats();
+    public static final int MAX_PRIORITY = 4;
 
+    private Stats stats = new Stats();
     public class Stats
     {
         private int turnaroundTime;

--- a/src/com/scu/coen383/team2/scheduling/SchedulePriority.java
+++ b/src/com/scu/coen383/team2/scheduling/SchedulePriority.java
@@ -1,0 +1,76 @@
+package com.scu.coen383.team2.scheduling;
+
+import java.util.HashMap;
+import java.util.Queue;
+
+public abstract class SchedulePriority extends ScheduleBase {
+     void updateStats(HashMap<Character, Float> arrivalTimeTable,
+                             HashMap<Character, Integer> finishTimeTable,
+                             Queue<Process>[] readyQueues,
+                             int startTime,
+                             int finishTime,
+                             Process process,
+                             ScheduleBase.Stats stats) {
+        if (!arrivalTimeTable.containsKey(process.getName()))   {
+            if (startTime < 100) {
+                arrivalTimeTable.put(process.getName(), process.getArrivalTime());
+                stats.addResponseTime(startTime - process.getArrivalTime());
+                stats.addWaitTime(startTime - process.getArrivalTime());
+            }
+        } else {
+            stats.addWaitTime(startTime - finishTimeTable.get(process.getName()));
+        }
+
+        // still have more than 1 quanta to run
+        if (process.getServiceQuanta() > 1) {
+
+            Process remaining = new Process(process);
+            remaining.setServiceTime(remaining.getServiceTime()-1);
+            readyQueues[remaining.getPriority()-1].add(remaining);
+            finishTimeTable.put(remaining.getName(), finishTime);
+
+        } else {
+            // current process terminate
+            stats.addTurnaroundTime(finishTime - process.getArrivalTime());
+            stats.addProcess();
+        }
+
+    }
+
+     void updatePriority(Queue<Process>[] readyQueues) {
+        for (int i = 0; i < MAX_PRIORITY; i++) {
+            for (Process p: readyQueues[i]) {
+                if (p.addAge() && i > 0) {
+                    // here we are, get p out from current level
+                    // then add it to higher level
+                    readyQueues[i].remove(p);
+                    readyQueues[i-1].add(p);
+                }
+            }
+        }
+    }
+     void statsState(int startTime, int finishTime, Process process, Stats stats) {
+
+        stats.addTurnaroundTime(finishTime - process.getArrivalTime());                     // finishTime - arrivalTime
+        stats.addResponseTime(startTime - process.getArrivalTime());                        // startTime - arrivalTime
+        stats.addWaitTime(finishTime - process.getArrivalTime() - process.getServiceTime());// turnaroundTime - serviceTime
+        stats.addProcess();
+    }
+
+     Process setScheduled(int startTime, float serviceTime, Process process) {
+        return new Process(
+                process.getName(),
+                process.getArrivalTime(),
+                serviceTime,
+                process.getPriority(),
+                startTime);
+    }
+
+     int highestQueue(Queue<Process>[] queues) {
+
+        for (int i = 0; i < MAX_PRIORITY; i++) {
+            if (!queues[i].isEmpty()) return i;
+        }
+        return MAX_PRIORITY;
+    }
+}

--- a/src/com/scu/coen383/team2/scheduling/SchedulePriority.java
+++ b/src/com/scu/coen383/team2/scheduling/SchedulePriority.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Queue;
 
 public abstract class SchedulePriority extends ScheduleBase {
-     void updateStats(HashMap<Character, Float> arrivalTimeTable,
+     protected void updateStats(HashMap<Character, Float> arrivalTimeTable,
                              HashMap<Character, Integer> finishTimeTable,
                              Queue<Process>[] readyQueues,
                              int startTime,
@@ -37,7 +37,7 @@ public abstract class SchedulePriority extends ScheduleBase {
 
     }
 
-     void updatePriority(Queue<Process>[] readyQueues) {
+    protected void updatePriority(Queue<Process>[] readyQueues) {
         for (int i = 0; i < MAX_PRIORITY; i++) {
             for (Process p: readyQueues[i]) {
                 if (p.addAge() && i > 0) {
@@ -49,7 +49,7 @@ public abstract class SchedulePriority extends ScheduleBase {
             }
         }
     }
-     void statsState(int startTime, int finishTime, Process process, Stats stats) {
+    protected void statsState(int startTime, int finishTime, Process process, Stats stats) {
 
         stats.addTurnaroundTime(finishTime - process.getArrivalTime());                     // finishTime - arrivalTime
         stats.addResponseTime(startTime - process.getArrivalTime());                        // startTime - arrivalTime
@@ -57,7 +57,7 @@ public abstract class SchedulePriority extends ScheduleBase {
         stats.addProcess();
     }
 
-     Process setScheduled(int startTime, float serviceTime, Process process) {
+    protected Process setScheduled(int startTime, float serviceTime, Process process) {
         return new Process(
                 process.getName(),
                 process.getArrivalTime(),
@@ -66,7 +66,7 @@ public abstract class SchedulePriority extends ScheduleBase {
                 startTime);
     }
 
-     int highestQueue(Queue<Process>[] queues) {
+    protected int highestQueue(Queue<Process>[] queues) {
 
         for (int i = 0; i < MAX_PRIORITY; i++) {
             if (!queues[i].isEmpty()) return i;


### PR DESCRIPTION
- add NonpreemptiveHighestPriorityFirstAging (bonus)
- add PreemptiveHighestPriorityFirstAging (bonus)
- create abstract class SchedulePriority to serve Priority Algorithms
- MAX_PRIORITY  was moved to ScheduleBase as a constant.

Here is the way I am using to implement Preemptive HPS with aging.
>            readyQueues:
>             [
>                 [...]
>                 [p0, p1, p2, ... pi]
>                 [...]
>                 [...]
>              ]
>              Each time, we pick up the first nonempty row as current Queue,
>              which is the row with highest priority.
>              When we do nonpreemptive HPF with Aging, we update each process in
>              this readyQueues, increase their age by one, if some of them wait
>              long enough, let's say it has waited for 5 quanta, we promote it
>              to a higher priority level, put it to the end of [i-1] row.
 

